### PR TITLE
Add ability for user to modify end data sent to Elasticsearch

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -10,11 +10,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/go-elasticsearch/v7/esapi"
-	"gopkg.in/go-extras/elogrus.v7/internal/bulk"
-
 	"github.com/elastic/go-elasticsearch/v7"
+	"github.com/elastic/go-elasticsearch/v7/esapi"
 	"github.com/sirupsen/logrus"
+	"gopkg.in/go-extras/elogrus.v7/internal/bulk"
 )
 
 var (


### PR DESCRIPTION
This adds the ModifyMessageFunc as a type, and adds it as a public field to ElasticHook so the user can set this function if needed. The function is called every time a message is created for elasticsearch if the field is not null. 

Solves #5 