### PR TITLE
check response status code from elasticsearch to catch error

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -231,6 +231,10 @@ func syncFireFunc(entry *logrus.Entry, hook *ElasticHook) error {
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode > 399 {
+		err = fmt.Errorf(res.String())
+	}
+
 	return err
 }
 


### PR DESCRIPTION
Hi, have a problem troubleshooting why my log isn't shipped to Elasticsearch. Turns out the error didn't catch properly.

This PR introduces improved error handling when ES returns errors, I believe this enhancement will provide better feedback to users.